### PR TITLE
Little fix for zip_before_city address, and fix for hidden_sub_label

### DIFF
--- a/_address-field.scss
+++ b/_address-field.scss
@@ -28,7 +28,7 @@
       padding-right: $gfs-form-spacing-x;
     }
 
-    .address_zip {
+    .ginput_right {
       padding-right: 0;
     }
   }

--- a/_main.scss
+++ b/_main.scss
@@ -95,7 +95,8 @@ textarea {
   padding: $gfs-label-padding;
 }
 
-.hidden_label .gfield_label {
+.hidden_label > label,
+label.hidden_sub_label {
   display: none;
 }
 


### PR DESCRIPTION
First i wish to thank you for that scss files at first look they are great, and till now i found not much that i can complain.
but there are 2 things that are not perfect:

- you miss to declare display none for hidden_sub_label 
- your style for gform_address_display_format is not for zip_before_city

this 2 commits fix both. 
fix for address work independent of zip/city order. because it target the right input instead of a field
fix for sub_label works but there are a few ways to target the label and sub_label

feel free to edit my fork before you merge it (if necessary), fork exist only for this PR